### PR TITLE
Fix scripts and make workflows more specific

### DIFF
--- a/.github/scripts/golangci-lint-version.sh
+++ b/.github/scripts/golangci-lint-version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "GOLANGCI_LINT_VERSION=$(cat .golangci.version)" >> "$GITHUB_ENV"

--- a/.github/scripts/golangci-lint-version.sh
+++ b/.github/scripts/golangci-lint-version.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -euco pipefail
 
 echo "GOLANGCI_LINT_VERSION=$(cat .golangci.version)" >> "$GITHUB_ENV"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**.go'
   pull_request:
+    paths:
+      - '**.go'
 
 permissions:
   contents: read
@@ -20,8 +24,3 @@ jobs:
       - uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
-  shellcheck:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - run: scripts/shellcheck.sh

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - run: echo "GOLANGCI_LINT_VERSION=$(cat .golangci.version)" >> $GITHUB_ENV
+      - run: .github/scripts/golangci-lint-version.sh
       - uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,17 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.sh'
+  pull_request:
+    paths:
+      - '**.sh'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: scripts/shellcheck.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := bash
 .ONESHELL:
-.SHELLFLAGS := -eu -o pipefail -c
+.SHELLFLAGS := -euco pipefail
 MAKEFLAGS += --warn-undefined-variables
 
 GOLANGCI_LINT_VERSION=$(shell cat .golangci.version)

--- a/scripts/install-lint.sh
+++ b/scripts/install-lint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euco pipefail
 
 mkdir -p "$INSTALL_DIR"
 cd "$INSTALL_DIR" || exit

--- a/scripts/install-lint.sh
+++ b/scripts/install-lint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 mkdir -p "$INSTALL_DIR"
 cd "$INSTALL_DIR" || exit

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # To not be surprised by CI failures.
 

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# To not be surprised by CI failures.
+set -euco pipefail
 
 make ci

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -euco pipefail
 
+git diff --quiet || { echo "You have unstaged changes; commit contents might not pass 'make ci'."; exit 1; }
 make ci

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 find . -iname "*.sh" -exec shellcheck {} +

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -euco pipefail
 
 find . -iname "*.sh" -exec shellcheck {} +


### PR DESCRIPTION
Minor adjustments that are hopefully helpful.

TIL: I think how the `paths:` specifier works, is that once a change is made into one of the specified paths, on all subsequent runs the given workflow will be ran, instead of ignoring commit that have changes to just a readme file etc. Will try in PR #3.

Seemingly the disadvantage with specifying the paths is that one cannot require all jobs to pass before merging. For this repo the only one who can merge is me so it doesn't matter but other than that the approach doesn't seem viable.